### PR TITLE
chore: Create scaffolding for IPC between UI and background service

### DIFF
--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -6,6 +6,7 @@ module.exports = Object.assign({}, mainJestConfig, {
   preset: null,
   roots: ['build/main'],
   testPathIgnorePatterns: [
-    "build/main/functionalTests"
+    "build/main/functionalTests",
+    "build/main/testUtils",
   ],
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     "_test_utils\.ts",
     "/functionalTests",
+    "/testUtils",
     "/types",
     "/index\.ts",
   ],

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "@relaycorp/relaynet-core": "^1.42.5",
     "buffer-to-arraybuffer": "0.0.6",
     "fastify": "^3.12.0",
+    "it-pipe": "^1.1.0",
     "pino": "^6.11.1",
+    "verror": "^1.10.0",
     "ws": "^7.4.3"
   },
   "optionalDependencies": {

--- a/src/PrivateGatewayError.ts
+++ b/src/PrivateGatewayError.ts
@@ -1,0 +1,3 @@
+import VError from 'verror';
+
+export default class PrivateGatewayError extends VError {}

--- a/src/example.spec.ts
+++ b/src/example.spec.ts
@@ -1,5 +1,0 @@
-import { foo } from './example';
-
-test('foo', () => {
-  expect(foo()).toEqual('bar');
-});

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,3 +1,0 @@
-export function foo(): string {
-  return 'bar';
-}

--- a/src/ipc/_utils.ts
+++ b/src/ipc/_utils.ts
@@ -1,0 +1,3 @@
+export async function sleep(seconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1_000));
+}

--- a/src/ipc/connectionStatus.spec.ts
+++ b/src/ipc/connectionStatus.spec.ts
@@ -1,0 +1,19 @@
+import pipe from 'it-pipe';
+
+import { asyncIterableToArray, iterableTake } from '../testUtils/iterables';
+import { ConnectionStatus, pollConnectionStatus } from './connectionStatus';
+
+describe('pollConnectionStatus', () => {
+  test('should temporarily cycle through all the possible statuses', async () => {
+    jest.setTimeout(30_000);
+
+    const statuses = await pipe(pollConnectionStatus(), iterableTake(4), asyncIterableToArray);
+
+    expect(statuses).toEqual([
+      ConnectionStatus.CONNECTED_TO_PUBLIC_GATEWAY,
+      ConnectionStatus.CONNECTED_TO_COURIER,
+      ConnectionStatus.DISCONNECTED_FROM_PUBLIC_GATEWAY,
+      ConnectionStatus.DISCONNECTED_FROM_ALL,
+    ]);
+  });
+});

--- a/src/ipc/connectionStatus.ts
+++ b/src/ipc/connectionStatus.ts
@@ -1,0 +1,22 @@
+import { sleep } from './_utils';
+
+export enum ConnectionStatus {
+  CONNECTED_TO_PUBLIC_GATEWAY,
+  CONNECTED_TO_COURIER,
+  DISCONNECTED_FROM_PUBLIC_GATEWAY,
+  DISCONNECTED_FROM_ALL,
+}
+
+export async function* pollConnectionStatus(): AsyncIterable<ConnectionStatus> {
+  yield ConnectionStatus.CONNECTED_TO_PUBLIC_GATEWAY;
+  await sleep(3);
+
+  yield ConnectionStatus.CONNECTED_TO_COURIER;
+  await sleep(5);
+
+  yield ConnectionStatus.DISCONNECTED_FROM_PUBLIC_GATEWAY;
+  await sleep(5);
+
+  yield ConnectionStatus.DISCONNECTED_FROM_ALL;
+  await sleep(2);
+}

--- a/src/ipc/courierSync.spec.ts
+++ b/src/ipc/courierSync.spec.ts
@@ -1,0 +1,18 @@
+import pipe from 'it-pipe';
+
+import { asyncIterableToArray } from '../testUtils/iterables';
+import { CourierSyncStatus, synchronizeWithCourier } from './courierSync';
+
+describe('synchronizeWithCourier', () => {
+  test('should temporarily cycle through all the possible statuses', async () => {
+    jest.setTimeout(20_000);
+
+    const statuses = await pipe(synchronizeWithCourier(), asyncIterableToArray);
+
+    expect(statuses).toEqual([
+      CourierSyncStatus.COLLECTING_CARGO,
+      CourierSyncStatus.WAITING,
+      CourierSyncStatus.DELIVERING_CARGO,
+    ]);
+  });
+});

--- a/src/ipc/courierSync.ts
+++ b/src/ipc/courierSync.ts
@@ -1,0 +1,28 @@
+import PrivateGatewayError from '../PrivateGatewayError';
+import { sleep } from './_utils';
+
+export enum CourierSyncStatus {
+  COLLECTING_CARGO,
+  WAITING,
+  DELIVERING_CARGO,
+}
+
+export class CourierSyncError extends PrivateGatewayError {}
+
+/**
+ * Initialize synchronization with courier and wait until it completes.
+ *
+ * This method will stream the current status of the synchronization.
+ *
+ * @throws CourierSyncError if the synchronization fails at any point
+ */
+export async function* synchronizeWithCourier(): AsyncIterable<CourierSyncStatus> {
+  yield CourierSyncStatus.COLLECTING_CARGO;
+  await sleep(5);
+
+  yield CourierSyncStatus.WAITING;
+  await sleep(5);
+
+  yield CourierSyncStatus.DELIVERING_CARGO;
+  await sleep(5);
+}

--- a/src/ipc/settings.spec.ts
+++ b/src/ipc/settings.spec.ts
@@ -1,0 +1,15 @@
+import { getPublicGatewayAddress, migratePublicGatewayAddress } from './settings';
+
+describe('getPublicGatewayAddress', () => {
+  test('should temporarily return braavos.relaycorp.cloud', async () => {
+    const publicGateway = await getPublicGatewayAddress();
+
+    expect(publicGateway).toEqual('braavos.relaycorp.cloud');
+  });
+});
+
+describe('migratePublicGatewayAddress', () => {
+  test('should temporarily accept any address', async () => {
+    await migratePublicGatewayAddress('kings-landing.relaycorp.cloud');
+  });
+});

--- a/src/ipc/settings.ts
+++ b/src/ipc/settings.ts
@@ -1,0 +1,22 @@
+import PrivateGatewayError from '../PrivateGatewayError';
+
+export class SettingError extends PrivateGatewayError {}
+
+/**
+ * Get the public address of the public gateway we're currently paired to.
+ */
+export function getPublicGatewayAddress(): Promise<string> {
+  return Promise.resolve('braavos.relaycorp.cloud');
+}
+
+/**
+ * Migrate to a new public gateway.
+ *
+ * @param _newAddress
+ * @throws SettingError if the migration fails
+ *
+ * This function will simply resolve when the migration completes successfully.
+ */
+export function migratePublicGatewayAddress(_newAddress: string): Promise<void> {
+  return Promise.resolve();
+}

--- a/src/testUtils/iterables.ts
+++ b/src/testUtils/iterables.ts
@@ -1,0 +1,33 @@
+/**
+ * Convert an AsyncIterable to an array.
+ */
+export async function asyncIterableToArray<T>(iterable: AsyncIterable<T>): Promise<readonly T[]> {
+  // tslint:disable-next-line:readonly-array
+  const values = [];
+  for await (const item of iterable) {
+    values.push(item);
+  }
+  return values;
+}
+
+/**
+ * Take the first `max` items from the iterable.
+ *
+ * @param max
+ */
+export function iterableTake<T>(max: number): (iterable: AsyncIterable<T>) => AsyncIterable<T> {
+  return async function* (iterable: AsyncIterable<T>): AsyncIterable<T> {
+    if (max <= 0) {
+      return;
+    }
+
+    let count = 0;
+    for await (const item of iterable) {
+      yield item;
+      count++;
+      if (max === count) {
+        break;
+      }
+    }
+  };
+}


### PR DESCRIPTION
This PR defines the API of the IPC-related functions that the UI will use to communicate with the background service.