### PR TITLE
fix(daemon/control): Require auth token in query string (in WS requests)

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -1140,9 +1140,9 @@
       }
     },
     "@relaycorp/ws-mock": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@relaycorp/ws-mock/-/ws-mock-1.4.11.tgz",
-      "integrity": "sha512-k8onWqsnpCQMC79E22/ZLtdS+yHmT6S0+k0u/UwAkhwltnoqKcggtapSxA5nXrYd7BIfhTU0KxQNaKPGeVY58A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@relaycorp/ws-mock/-/ws-mock-1.5.0.tgz",
+      "integrity": "sha512-QK4tewrwXSgqjflpGZrrZ5eDSlzH5+XSZ5bR4c0j1eqdEgLCOeSGJO5Cxvg6BwYoSerHuMSkFM+O6pfC3MD9Rg==",
       "dev": true,
       "requires": {
         "ws": "^7.4.4"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@relaycorp/relaynet-testing": "^1.1.5",
     "@relaycorp/shared-config": "^1.4.13",
-    "@relaycorp/ws-mock": "^1.4.11",
+    "@relaycorp/ws-mock": "^1.5.0",
     "@types/default-gateway": "^3.0.1",
     "@types/is-valid-domain": "0.0.0",
     "@types/jest": "^26.0.22",

--- a/packages/daemon/src/server/control/README.md
+++ b/packages/daemon/src/server/control/README.md
@@ -17,10 +17,10 @@ When the daemon starts as a `fork`ed process, it will send the authentication to
 }
 ```
 
-Requests to Control endpoints should include the `value` as a Bearer token in the `Authorization` header. For example:
+Requests to Control endpoints should include the `value` in the query string parameter `auth`. For example:
 
 ```
-Authorization: Bearer s3cr3t
+http://127.0.0.1:13276/_control/sub-path?auth=s3cr3t
 ```
 
 When authentication fails, HTTP requests would result in `401` responses and WebSocket requests would be closed with the `1008` status code.

--- a/packages/daemon/src/server/websocket.spec.ts
+++ b/packages/daemon/src/server/websocket.spec.ts
@@ -80,11 +80,7 @@ describe('WebSocket server configuration', () => {
   test('Request should be refused if auth is required and invalid token is passed', async () => {
     const mockHandler = jest.fn();
     const wsServer = makeWebSocketServer(mockHandler, mockLogging.logger, 'auth-token');
-    const mockClient = new MockClient(
-      wsServer,
-      { authorization: 'not the auth token' },
-      '/?auth=invalid',
-    );
+    const mockClient = new MockClient(wsServer, {}, '/?auth=invalid');
 
     await mockClient.connect();
     await expect(mockClient.waitForPeerClosure()).resolves.toEqual({

--- a/packages/daemon/src/server/websocket.ts
+++ b/packages/daemon/src/server/websocket.ts
@@ -1,7 +1,6 @@
 import { Logger } from 'pino';
 import { Duplex } from 'stream';
 import WebSocket, { createWebSocketStream, Server } from 'ws';
-import { getBearerTokenFromAuthHeader } from '../utils/auth';
 
 export type WebsocketServerFactory = (logger: Logger, controlAuthToken: string) => Server;
 
@@ -18,8 +17,9 @@ export function makeWebSocketServer(
   const isAuthRequired = !!authToken;
 
   wsServer.on('connection', (socket, request) => {
-    const bearerToken = getBearerTokenFromAuthHeader(request.headers.authorization);
-    if (isAuthRequired && authToken !== bearerToken) {
+    const url = new URL(request.url!!, 'http://127.0.0.1');
+    const requestToken = url.searchParams.get('auth');
+    if (isAuthRequired && authToken !== requestToken) {
       logger.info('Refusing unauthenticated request');
       socket.close(1008, 'Authentication is required');
       return;

--- a/packages/daemon/src/testUtils/websocket.ts
+++ b/packages/daemon/src/testUtils/websocket.ts
@@ -13,6 +13,6 @@ export function mockWebsocketStream(): void {
 
 export class MockAuthClient extends MockClient {
   constructor(wsServer: WSServer, authToken: string, headers?: { readonly [key: string]: string }) {
-    super(wsServer, { ...(headers ?? {}), authorization: `Bearer ${authToken}` });
+    super(wsServer, headers, `/?auth=${authToken}`);
   }
 }


### PR DESCRIPTION
Because `WebSocket` in Electron can't set request headers.