### PR TITLE
chore(CI): Fix webpack builds on Windows

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,9 @@
+set -o nounset -o errexit -o pipefail
+
+cd packages/daemon
+npm run build
+# Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
+npm prune --omit=dev
+
+cd ../ui
+npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,18 +58,8 @@ jobs:
       - run: npm test
 
       - name: Build
-        working-directory: packages
         shell: bash
-        run: |
-          set -o nounset -o errexit -o pipefail
-
-          cd daemon
-          npm run build
-          # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
-          npm prune --omit=dev
-
-          cd ../ui
-          npm run build
+        run: .github/scripts/build.sh
 
       - run: npm run dist
         working-directory: packages/ui
@@ -163,16 +153,10 @@ jobs:
         if: ${{ steps.version-artefact.outcome == 'success' }}
         working-directory: packages/ui
 
-      - run: npm run build
+      - name: Build
         if: ${{ steps.version-artefact.outcome == 'success' }}
-        working-directory: packages/daemon
-      # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
-      - run: npm prune --omit=dev
-        if: ${{ steps.version-artefact.outcome == 'success' }}
-        working-directory: packages/daemon
-      - run: npm run build
-        if: ${{ steps.version-artefact.outcome == 'success' }}
-        working-directory: packages/ui
+        shell: bash
+        run: .github/scripts/build.sh
 
       - name: Set version in app
         if: ${{ steps.version-artefact.outcome == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - run: npm run build
         working-directory: packages/daemon
       # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
-      - run: npm prune --production
+      - run: npm prune --omit=dev
         working-directory: packages/daemon
       - run: npm run build
         working-directory: packages/ui
@@ -159,6 +159,15 @@ jobs:
 
       - run: npm run build
         if: ${{ steps.version-artefact.outcome == 'success' }}
+        working-directory: packages/daemon
+      # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
+      - run: npm prune --omit=dev
+        if: ${{ steps.version-artefact.outcome == 'success' }}
+        working-directory: packages/daemon
+      - run: npm run build
+        if: ${{ steps.version-artefact.outcome == 'success' }}
+        working-directory: packages/ui
+
       - name: Set version in app
         if: ${{ steps.version-artefact.outcome == 'success' }}
         run: npm version ${{ steps.set-version.outputs.content }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       - run: npm run static-checks
   ci:
     name: ci-${{ matrix.os }}
-    needs: static-checks
+#    needs: static-checks
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       - run: npm run static-checks
   ci:
     name: ci-${{ matrix.os }}
-#    needs: static-checks
+    needs: static-checks
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -55,17 +55,16 @@ jobs:
       - run: ../../node_modules/.bin/npm ci
         working-directory: packages/ui
 
+      - run: npm test
+
       - run: npm run build
-        timeout-minutes: 5
         working-directory: packages/daemon
-#      - run: npm prune --production
-#        timeout-minutes: 5
-#        working-directory: packages/daemon
+      # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
+      - run: npm prune --production
+        working-directory: packages/daemon
       - run: npm run build
-        timeout-minutes: 5
         working-directory: packages/ui
 
-#      - run: npm run test:ci
       - run: npm run dist
         working-directory: packages/ui
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,15 @@ jobs:
 
       - run: npm run build
         timeout-minutes: 5
-      - run: npm run test:ci
+        working-directory: packages/daemon
+      - run: npm prune --production
+        timeout-minutes: 5
+        working-directory: packages/daemon
+      - run: npm run build
+        timeout-minutes: 5
+        working-directory: packages/ui
+
+#      - run: npm run test:ci
       - run: npm run dist
         working-directory: packages/ui
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
       - run: npm prune --omit=dev
         working-directory: packages/daemon
+      - run: ../../node_modules/.bin/npm ci
+        working-directory: packages/ui
       - run: npm run build
         working-directory: packages/ui
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,18 @@ jobs:
 
       - run: npm test
 
-      - run: npm run build
-        working-directory: packages/daemon
-      # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
-      - run: npm prune --omit=dev
-        working-directory: packages/daemon
-      - run: ../../node_modules/.bin/npm ci
-        working-directory: packages/ui
-      - run: npm run build
-        working-directory: packages/ui
+      - name: Build
+        working-directory: packages
+        run: |
+          set -o nounset -o errexit -o pipefail
+
+          cd daemon
+          npm run build
+          # Work around https://github.com/webpack-contrib/copy-webpack-plugin/issues/59
+          npm prune --omit=dev
+
+          cd ../ui
+          npm run build
 
       - run: npm run dist
         working-directory: packages/ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
       - run: npm run build
         timeout-minutes: 5
         working-directory: packages/daemon
-      - run: npm prune --production
-        timeout-minutes: 5
-        working-directory: packages/daemon
+#      - run: npm prune --production
+#        timeout-minutes: 5
+#        working-directory: packages/daemon
       - run: npm run build
         timeout-minutes: 5
         working-directory: packages/ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Build
         working-directory: packages
+        shell: bash
         run: |
           set -o nounset -o errexit -o pipefail
 

--- a/jest.config.ci.json
+++ b/jest.config.ci.json
@@ -1,7 +1,0 @@
-{
-  "collectCoverageFrom": ["**/*.js"],
-  "moduleFileExtensions": ["js"],
-  "preset": null,
-  "roots": ["build"],
-  "testPathIgnorePatterns": ["build/functionalTests", "build/testUtils"]
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "static-checks:lint": "tslint --project .",
     "static-checks:prettier": "prettier \"packages/**/*.ts\" --list-different",
     "test": "lerna run test",
-    "test:ci": "lerna run test:ci:unit:jest",
     "clean": "lerna run clean"
   },
   "engines": {

--- a/packages/daemon/jest.config.ci.js
+++ b/packages/daemon/jest.config.ci.js
@@ -1,7 +1,0 @@
-const mainJestConfig = require('./jest.config');
-const ciJestConfig = require('../../jest.config.ci.json');
-
-module.exports = {
-  ...mainJestConfig,
-  ...ciJestConfig,
-};

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -7,7 +7,6 @@
     "start": "ts-node-dev --files src/bin/gateway-daemon.ts",
     "test": "jest --coverage",
     "test:functional": "jest --config jest.config.functional.js --runInBand --detectOpenHandles",
-    "test:ci:unit:jest": "jest --config jest.config.ci.js --coverage",
     "typeorm": "ts-node-dev ./node_modules/typeorm/cli.js"
   },
   "private": "true",

--- a/packages/ui/jest.config.ci.js
+++ b/packages/ui/jest.config.ci.js
@@ -1,7 +1,0 @@
-const mainJestConfig = require('./jest.config');
-const ciJestConfig = require('../../jest.config.ci.json');
-
-module.exports = {
-  ...mainJestConfig,
-  ...ciJestConfig,
-};

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -36,6 +36,7 @@
         "electron": "^16.2.6",
         "electron-builder": "^23.1.0",
         "fetch-mock-jest": "^1.5.1",
+        "graceful-fs": "^4.2.10",
         "html-webpack-plugin": "^5.5.0",
         "is-valid-domain": "0.1.6",
         "it-pipe": "^1.1.0",

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -49,8 +49,8 @@
         "react-dom": "^17.0.1",
         "ts-jest": "^27.1.1",
         "ts-loader": "^9.3.0",
-        "webpack": "^5.65.0",
-        "webpack-cli": "^4.9.1"
+        "webpack": "^5.74.0",
+        "webpack-cli": "^4.10.0"
       }
     },
     "../daemon": {
@@ -58,7 +58,7 @@
       "dependencies": {
         "@relaycorp/cogrpc": "^1.3.55",
         "@relaycorp/keystore-db": "^1.5.21",
-        "@relaycorp/relaynet-core": "^1.81.5",
+        "@relaycorp/relaynet-core": "^1.81.7",
         "@relaycorp/relaynet-poweb": "^1.6.30",
         "abortable-iterator": "^3.0.0",
         "bson": "^4.4.1",
@@ -74,7 +74,7 @@
         "it-pipe": "^1.1.0",
         "make-promises-safe": "^5.1.0",
         "pino": "^7.6.0",
-        "pino-pretty": "^7.3.0",
+        "pino-pretty": "^8.1.0",
         "reflect-metadata": "^0.1.13",
         "split2": "^4.1.0",
         "sqlite3": "^5.0.8",
@@ -100,7 +100,7 @@
         "@types/tcp-port-used": "^1.0.0",
         "@types/verror": "^1.10.5",
         "@types/ws": "^8.2.2",
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "jest": "^27.4.5",
         "jest-extended": "^2.0.0",
         "light-my-request": "^4.12.0",
@@ -10837,9 +10837,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -10847,11 +10847,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -10864,7 +10864,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -14013,7 +14013,7 @@
       "requires": {
         "@relaycorp/cogrpc": "^1.3.55",
         "@relaycorp/keystore-db": "^1.5.21",
-        "@relaycorp/relaynet-core": "^1.81.5",
+        "@relaycorp/relaynet-core": "^1.81.7",
         "@relaycorp/relaynet-poweb": "^1.6.30",
         "@relaycorp/relaynet-testing": "^2.2.21",
         "@relaycorp/ws-mock": "^2.4.1",
@@ -14035,7 +14035,7 @@
         "env-paths": "^2.2.1",
         "env-var": "^7.1.1",
         "fastify": "^3.25.2",
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "is-valid-domain": "0.1.6",
         "it-pipe": "^1.1.0",
         "jest": "^27.4.5",
@@ -14043,7 +14043,7 @@
         "light-my-request": "^4.12.0",
         "make-promises-safe": "^5.1.0",
         "pino": "^7.6.0",
-        "pino-pretty": "^7.3.0",
+        "pino-pretty": "^8.1.0",
         "reflect-metadata": "^0.1.13",
         "split2": "^4.1.0",
         "sqlite3": "^5.0.8",
@@ -19532,9 +19532,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -19542,11 +19542,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -19559,7 +19559,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -36,7 +36,6 @@
         "electron": "^16.2.6",
         "electron-builder": "^23.1.0",
         "fetch-mock-jest": "^1.5.1",
-        "graceful-fs": "^4.2.10",
         "html-webpack-plugin": "^5.5.0",
         "is-valid-domain": "0.1.6",
         "it-pipe": "^1.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,6 +49,7 @@
     "electron": "^16.2.6",
     "electron-builder": "^23.1.0",
     "fetch-mock-jest": "^1.5.1",
+    "graceful-fs": "^4.2.10",
     "html-webpack-plugin": "^5.5.0",
     "is-valid-domain": "0.1.6",
     "it-pipe": "^1.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,7 +62,7 @@
     "react-dom": "^17.0.1",
     "ts-jest": "^27.1.1",
     "ts-loader": "^9.3.0",
-    "webpack": "^5.65.0",
-    "webpack-cli": "^4.9.1"
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,6 @@
     "electron": "^16.2.6",
     "electron-builder": "^23.1.0",
     "fetch-mock-jest": "^1.5.1",
-    "graceful-fs": "^4.2.10",
     "html-webpack-plugin": "^5.5.0",
     "is-valid-domain": "0.1.6",
     "it-pipe": "^1.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,14 +11,13 @@
     "report-dependencies": "node report-dependencies.js",
     "build": "run-s --print-name report-dependencies tsc webpack",
     "webpack": "webpack --config ./webpack.config.js",
-    "tsc": "tsc -p tsconfig.json",
+    "tsc": "tsc",
     "start": "electron ./app/main.js",
     "clean": "rimraf build test coverage dist app",
     "cov": "run-s build test:unit && opn coverage/lcov-report/index.html",
     "dist": "electron-builder --config electron-builder.yml --publish=never",
     "test": "cross-env NODE_OPTIONS='--unhandled-rejections=warn' jest --coverage",
-    "test:functional": "jest --config jest.config.functional.js --runInBand --detectOpenHandles",
-    "test:ci:unit:jest": "cross-env NODE_OPTIONS='--unhandled-rejections=warn' jest --config jest.config.ci.js --coverage"
+    "test:functional": "jest --config jest.config.functional.js --runInBand --detectOpenHandles"
   },
   "private": "true",
   "dependencies": {

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -1,3 +1,6 @@
+// Work around "EMFILE: too many open files error" on Windows
+require('graceful-fs').gracefulify(require('fs'));
+
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyPlugin = require("copy-webpack-plugin");

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -81,6 +81,8 @@ module.exports = [
                 '**/README.md',
                 '**/jest.*.js',
                 '**/tsconfig.json',
+                '**/*.d.ts',
+                '**/*.map.js',
               ],
             },
           },

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = [
           { from: './node_modules/daemon/**/*', to: '.' },
           { from: './node_modules/daemon/ormconfig.json', to: '.' }
         ],
+        options: { concurrency: 50 },
       }),
     ]
   },

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -70,10 +70,22 @@ module.exports = [
       new CopyPlugin({
         patterns: [
           { from: './src/electron/template.package.json', to: 'package.json' },
-          { from: './node_modules/daemon/**/*', to: '.' },
+          {
+            from: './node_modules/daemon/**/*',
+            to: '.',
+            globOptions: {
+              gitignore: true,
+              ignore: [
+                '**/coverage/**',
+                '**/src/**',
+                '**/README.md',
+                '**/jest.*.js',
+                '**/tsconfig.json',
+              ],
+            },
+          },
           { from: './node_modules/daemon/ormconfig.json', to: '.' }
         ],
-        options: { concurrency: 50 },
       }),
     ]
   },

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -1,6 +1,3 @@
-// Work around "EMFILE: too many open files error" on Windows
-require('graceful-fs').gracefulify(require('fs'));
-
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyPlugin = require("copy-webpack-plugin");


### PR DESCRIPTION
It started to fail suddenly with:

```
(...)

ERROR in EMFILE: too many open files, open 'D:\a\awala-gateway-desktop\awala-gateway-desktop\packages\ui\node_modules\daemon\node_modules\date-fns\fp\isExists\index.js.flow'

ERROR in EMFILE: too many open files, open 'D:\a\awala-gateway-desktop\awala-gateway-desktop\packages\ui\node_modules\daemon\node_modules\ajv\lib\dotjs\const.js'

webpack 5.73.0 compiled with 7460 errors in 190046 ms
```

The culprit was https://github.com/webpack-contrib/copy-webpack-plugin/issues/59